### PR TITLE
EDGE-256 fixing incorrect epoch advance

### DIFF
--- a/internal/controller/anyapplication_controller.go
+++ b/internal/controller/anyapplication_controller.go
@@ -270,9 +270,10 @@ func mergeStatus(currentStatus *dcpv1.AnyApplicationStatus, newStatus *dcpv1.Any
 		msg += fmt.Sprintf("Owner changed to '%s'. ", newStatus.Ownership.Owner)
 		updated = true
 	}
-	if newStatus.Ownership.Epoch != currentStatus.Ownership.Epoch {
-		currentStatus.Ownership.Epoch = newStatus.Ownership.Epoch
-		msg += fmt.Sprintf("Epoch changed to '%d'.", newStatus.Ownership.Epoch)
+	epoch := max(newStatus.Ownership.Epoch, currentStatus.Ownership.Epoch)
+	if currentStatus.Ownership.Epoch != epoch {
+		currentStatus.Ownership.Epoch = epoch
+		msg += fmt.Sprintf("Epoch changed to '%d'.", epoch)
 		updated = true
 	}
 


### PR DESCRIPTION
- This pull request updates the logic for merging the Ownership.Epoch field in the AnyApplicationStatus within the mergeStatus function. 
- Previously, the code directly set currentStatus.Ownership.Epoch to newStatus.Ownership.Epoch if they differed. With this change, the function now sets the Epoch to the maximum value between the current and new status epochs. 
- This ensures that the epoch always increases or stays the same, preventing potential regressions or unintended downgrades in epoch value. The change also updates the related log message to reflect the new value. This improves the robustness and correctness of ownership state management.