### PR TITLE
Edge 293 publishing docs site

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,7 +4,7 @@ on:
   # Runs on pushes targeting the `main` branch. Change this to `master` if you're
   # using the `master` branch as the default branch.
   push:
-    branches: [EDGE-293-improve-anyapplication-controller-validation-with-webhook]
+    branches: [main]
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing documentation in the anyapplication-controller repository. The main change is a migration from the built-in GitHub Pages deployment actions to using the peaceiris/actions-gh-pages action for deploying documentation.

### Key Changes

- Introduced a DOCS_TARGET_DIR environment variable to specify the documentation target directory.
- Updated workflow permissions to grant write access to contents.
- Switched from actions/configure-pages and actions/deploy-pages to peaceiris/actions-gh-pages for deployment.
- Simplified the workflow by consolidating deployment steps and removing redundant jobs.
- Configured the deployment to use the gh-pages branch and the ./docs/.vitepress/dist directory.
- Ensured deployment only runs on non-pull-request events.

